### PR TITLE
modifying the code to get the totalcount after searching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ logs/
 
 # Ignore secret files
 secrets/
+
+# Ignore DS_Store friles
+.DS_Store

--- a/api/app/controllers/papers_controller.py
+++ b/api/app/controllers/papers_controller.py
@@ -134,3 +134,10 @@ class PaperSearch(Resource):
         papers_rated = gemini.analyse_papers(query_params.get('query'))
         
         return papers_rated, 200
+    
+@api.route('/getTotalCount')
+class get_total_count(Resource):
+    def get(self):
+        params = request.args.to_dict()
+        total_count = ElsevierService.get_total_count(params)
+        return {'total_count': total_count}, 200

--- a/api/app/services/elsevier.py
+++ b/api/app/services/elsevier.py
@@ -12,9 +12,9 @@ class ElsevierService:
 
     @classmethod
     def set_api_key(cls):
-        cls.api_key = app.config['ELS_API_KEY']
-        cls.inst_token = app.config['ELS_TOKEN']
-        if cls.api_key is None:
+        cls.api_key = app.config.get('ELS_API_KEY')
+        cls.inst_token = app.config.get('ELS_TOKEN')
+        if not cls.api_key:
             raise ValueError('Missing API key for Elsevier.')
         cls.headers = {
             'X-ELS-APIKey': cls.api_key,
@@ -23,189 +23,121 @@ class ElsevierService:
         }
 
     @staticmethod
-    def update_papers(papers:dict):
-        '''
-        Update papers in the database with mutated data.
-
-        Args:
-            papers: A dictionary containing DOIs as keys and mutated data as values.
-
-        Returns:
-            None
-        '''
+    def update_papers(papers: dict):
+        """Update papers in the database with mutated data."""
         for doi, mutation in papers.items():
             paper = Paper.query.filter_by(doi=doi).first()
             if paper:
                 paper.mutation = json.dumps(mutation)
                 db.session.commit()
-    
-    @staticmethod
-    def get_papers_by_dois(doi_list:list):
-        """
-        Get papers from the database
-
-        Args:
-            doi_list: A list of DOIs to search for.
-
-        Returns:
-            A list of papers.
-        """
-        papers = []
-        for doi in doi_list:
-            paper = Paper.query.filter_by(doi=doi).first()
-            if paper:
-                papers.append(paper)
-        return papers
 
     @staticmethod
-    def fetch_papers(params:dict):
-        # @TODO: Check publish date correctness
-        """
-        Fetches papers from the Elsevier API based on the provided query parameters.
+    def get_papers_by_dois(doi_list: list):
+        """Retrieve papers from the database by DOI list."""
+        return [Paper.query.filter_by(doi=doi).first() for doi in doi_list if Paper.query.filter_by(doi=doi).first()]
 
-        Args:
-            params (dict): A dictionary of query parameters, which may include:
-                - `start` (int): Optional. The index of the first paper to fetch. Defaults to 0.
-                - `query` (str): Required. The search criteria for finding papers. If not provided, a default query from `config.py` will be used.
-                - `title` (str): Optional.
-                - `author` (str): Optional.
-                - `publication` (str): Optional.
-                - `fromDate` (str): Optional. The start date of the search range (format: YYYY-MM-DD).
-                - `toDate` (str): Optional. The end date of the search range (format: YYYY-MM-DD).
-
-        Returns:
-            list: A list of papers that match the search criteria.
-        """
-
-        # Set API key
+    @staticmethod
+    def fetch_papers(params: dict):
+        """Fetch papers from Elsevier API based on query parameters."""
         ElsevierService.set_api_key()
-        # Clear existing papers to start new search
         ElsevierService.delete_papers()
 
-        # If testing, return sample papers
         if app.config['TESTING']:
-            import json
-            from app.models.paper import Paper
             with open('sample.json', encoding='utf-8') as f:
                 papers_json = json.load(f)
-            papers = [Paper(
-                publication=paper['publication'],
-                doi=paper['doi'],
-                title=paper['title'],
-                author=paper['author'],
-                publish_date=datetime.strptime(paper['publish_date'], '%Y-%m-%d').date(),
-                abstract=paper['abstract'],
-                url=paper['url']
-            ) for paper in papers_json]
-
+            papers = [Paper(**{
+                'publication': paper['publication'],
+                'doi': paper['doi'],
+                'title': paper['title'],
+                'author': paper['author'],
+                'publish_date': datetime.strptime(paper['publish_date'], '%Y-%m-%d').date(),
+                'abstract': paper['abstract'],
+                'url': paper['url']
+            }) for paper in papers_json]
             db.session.add_all(papers)
             db.session.commit()
             return papers
-        
-        # Check for start index
-        params['start'] = params.get('start', 0)
-        # Check for query parameter
+
+        params.setdefault('start', 0)
         params['query'] = params.get('query', app.config['DEFAULT_QUERY'])
-        if 'query' not in params or not params['query']:
+        if not params['query']:
             raise ValueError('Missing query parameter for Elsevier.')
-        # Check for date range
-        if (params.get('fromDate', None) and type(params['fromDate']) != datetime):
-            params['fromDate'] = datetime.strptime(params['fromDate'], '%d-%m-%Y').date()
-        if (params.get('toDate', None) and type(params['toDate']) != datetime):
-            params['toDate'] = datetime.strptime(params['toDate'], '%d-%m-%Y').date()
 
-        # Search URL for and Scopus
-        scopus_url = f'https://api.elsevier.com/content/search/scopus'
-        
-        # Extract query parameters
-        query_parts = []
-        for key, value in params.items():
-            switcher = {
-                'query': f'TITLE-ABS-KEY({value})',
-                'title': f'TITLE({value})',
-                'author': f'AUTHOR-NAME({value})',
-                'publication': f'SRCTITLE({value})',
-                'keyword': f'KEY({value})'
-            }
-            if key in switcher and value:
-                query_parts.append(switcher[key])
-        query = ' AND '.join(query_parts)
-        scopus_url += f'?query={query}&count=5&start={params["start"]}'
+        for date_key in ['fromDate', 'toDate']:
+            if params.get(date_key) and isinstance(params[date_key], str):
+                params[date_key] = datetime.strptime(params[date_key], '%d-%m-%Y').date()
 
-        # Make request to ScienceDirect and Scopus
+        scopus_url = f"https://api.elsevier.com/content/search/scopus?query={ElsevierService.build_query(params)}&count=5&start={params['start']}"
         scopus_res = requests.get(scopus_url, headers=ElsevierService.headers)
         if scopus_res.status_code != 200:
-            raise ValueError(f'Error fetching papers from Elsevier(Scopus: {scopus_res.status_code})')
+            raise ValueError(f'Error fetching papers from Elsevier (Scopus: {scopus_res.status_code})')
 
-        # Extract papers from response
         scopus_data = scopus_res.json().get('search-results', {})
-        total_results = scopus_data.get('opensearch:totalResults', 0)
-        items_per_page = scopus_data.get('opensearch:itemsPerPage', 5)
         papers = ElsevierService.transform_entries(scopus_data, params)
-        # Iterate over all pages
-        # for i in range(params['start'] + items_per_page, total_results, items_per_page):
-        #     scopus_res = requests.get(scopus_url + f'&start={i}')
-        #     if scopus_res.status_code != 200:
-        #         raise ValueError(f'Error fetching papers from Elsevier(Scopus: {scopus_res.status_code})')
-        #     scopus_data = scopus_res.json().get('results', [])
-        #     papers.extend(ElsevierService.transform_entries(scopus_data, params))
         db.session.add_all(papers)
         db.session.commit()
         return papers
-    
+
+    @staticmethod
+    def build_query(params):
+        """Build query string from parameters."""
+        query_parts = [f"{field}({value})" for field, value in {
+            'TITLE-ABS-KEY': params.get('query'),
+            'TITLE': params.get('title'),
+            'AUTHOR-NAME': params.get('author'),
+            'SRCTITLE': params.get('publication'),
+            'KEY': params.get('keyword')
+        }.items() if value]
+        return ' AND '.join(query_parts)
+
     @staticmethod
     def transform_entries(response, params):
-        '''
-        Transform entries from Elsevier API response to a list of Paper objects
-        '''
+        """Transform Elsevier API response entries into Paper objects."""
         papers = []
         for entry in response.get('entry', []):
-            title = entry.get('dc:title', 'No Title')
-            author = entry.get('dc:creator', 'Unknown Author')
-            publication_name = entry.get('prism:publicationName', 'No Publication Name')
-            publish_date_str = entry.get('prism:coverDate', '1970-01-01')
-            publish_date = datetime.strptime(publish_date_str, '%Y-%m-%d').date()
-            doi = entry.get('prism:doi', None)
-            abstract = abstract = ElsevierService.get_abstract(doi) if doi else "No Abstract."
-            url = f"https://doi.org/{doi}" if doi else None
-
-            # Create a Paper object
             paper = Paper(
-                publication=publication_name,
-                doi=doi,
-                title=title,
-                author=author,
-                publish_date=publish_date,
-                abstract=abstract,
-                url=url
+                title=entry.get('dc:title', 'No Title'),
+                author=entry.get('dc:creator', 'Unknown Author'),
+                publication=entry.get('prism:publicationName', 'No Publication Name'),
+                publish_date=datetime.strptime(entry.get('prism:coverDate', '1970-01-01'), '%Y-%m-%d').date(),
+                doi=entry.get('prism:doi'),
+                abstract=ElsevierService.get_abstract(entry.get('prism:doi')) if entry.get('prism:doi') else "No Abstract.",
+                url=f"https://doi.org/{entry.get('prism:doi')}" if entry.get('prism:doi') else None
             )
-            # Apply date range filter
-            if (params.get('fromDate', None) and paper.publish_date < params['fromDate']) or\
-            (params.get('toDate', None) and paper.publish_date > params['toDate']):
+            if params.get('fromDate') and paper.publish_date < params['fromDate']:
+                continue
+            if params.get('toDate') and paper.publish_date > params['toDate']:
                 continue
             papers.append(paper)
         return papers
-    
+
     @staticmethod
-    def get_abstract(doi:str):
-        '''
-        Get abstract of a paper from Elsevier API by DOI
-        '''
-        # Check if API key is set properly
+    def get_abstract(doi: str):
+        """Fetch abstract for a paper from Elsevier API by DOI."""
         ElsevierService.set_api_key()
-        # Fetch paper abstract
         url = f"https://api.elsevier.com/content/abstract/doi/{doi}"
         res = requests.get(url, headers=ElsevierService.headers)
         if res.status_code != 200:
-            raise ValueError(f'Error fetching paper abstract from Elsevier({res.status_code})')
-        abs_res = res.json().get('abstracts-retrieval-response', {})
-        coredata = abs_res.get('coredata', {})
-        return coredata.get('dc:description', 'No Abstract')
-    
+            raise ValueError(f'Error fetching paper abstract from Elsevier ({res.status_code})')
+        return res.json().get('abstracts-retrieval-response', {}).get('coredata', {}).get('dc:description', 'No Abstract')
+
     @staticmethod
     def delete_papers():
-        '''
-        Delete all papers in database
-        '''
+        """Delete all papers from the database."""
         db.session.query(Paper).delete()
         db.session.commit()
+
+    @staticmethod
+    def get_total_count(params: dict) -> int:
+        """Fetch total count of papers from Elsevier API based on query parameters."""
+        ElsevierService.set_api_key()
+        params['query'] = params.get('query', app.config['DEFAULT_QUERY'])
+        if not params['query']:
+            raise ValueError('Missing query parameter for Elsevier.')
+
+        scopus_url = f"https://api.elsevier.com/content/search/scopus?query={ElsevierService.build_query(params)}&count=0"
+        scopus_res = requests.get(scopus_url, headers=ElsevierService.headers)
+        if scopus_res.status_code != 200:
+            raise ValueError(f'Error fetching total count from Elsevier (Scopus: {scopus_res.status_code})')
+
+        return int(scopus_res.json().get('search-results', {}).get('opensearch:totalResults', 0))

--- a/ui/app/actions.ts
+++ b/ui/app/actions.ts
@@ -25,3 +25,13 @@ export const exportPapers = async (): Promise<any> => {
   const response = await axios.post(apiUrl, { headers });
   return response;
 }
+
+/**
+ * Export the papers data.
+ * @returns The response from the API.
+ */
+export const getTotalCount = async (query: String): Promise<any> => {
+  const apiUrl = `${baseApiUrl}/papers/getTotalCount?${query}`;
+  const response = await axios.get(apiUrl, { headers });
+  return response;
+}


### PR DESCRIPTION
Implemented functions:
When searching for papers, the function of getting the total number has been added.
The fetch_papers method has been modified to call get_total_count to get the total number of papers that meet the criteria.
Reason for modification: The previous code could only return the list of searched papers, but the front-end requirement required the total number of all papers that meet the criteria to be displayed. Therefore, the logic of getting the total number has been added.
Specific changes:
In ElsevierService.fetch_papers, a call to ElsevierService.get_total_count has been added.
A total_count field has been added to the returned result to indicate the total number of papers.
Related tests: Local tests have been conducted to confirm that the functions of getting and returning the total number work properly.