### PR TITLE
UI/features/proceed bugs fix

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -9,15 +9,30 @@ export default function Page() {
   const [showResults, setShowResults] = useState(false); // Status to manage whether to display results
   const resultsRef = useRef<HTMLDivElement>(null); // Create a reference
 
-  const handleProceedClick = () => {
-    setShowResults(true); // Set to true to show the Results component
-  };
 
-  useEffect(() => {
-    if (showResults && resultsRef.current) {
-      resultsRef.current.scrollIntoView({ behavior: 'smooth' }); // Smooth scrolling to the Results section
-    }
-  }, [showResults]);
+  const handleProceedClick = () => {
+    setShowResults(true); // Set to true to display the result component
+  
+
+  // Make sure to scroll to the results section on each click
+  if (resultsRef.current) {
+    const elementPosition = resultsRef.current.getBoundingClientRect().top + window.scrollY;
+    window.scrollTo({
+      top: elementPosition + resultsRef.current.offsetHeight- 800, // Scroll to the bottom of the results section
+      behavior: 'smooth',
+    });
+  }
+};
+
+useEffect(() => {
+  if (showResults && resultsRef.current) {
+    const elementPosition = resultsRef.current.getBoundingClientRect().top + window.scrollY;
+    window.scrollTo({
+      top: elementPosition + resultsRef.current.offsetHeight -800, 
+      behavior: 'smooth',
+    });
+  }
+}, [showResults]); // Perform scrolling when showResults changes
 
   return (
     <div className={style.main}>

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -7,7 +7,7 @@ import style from './page.module.css';
 
 export default function Page() {
   const [showResults, setShowResults] = useState(false); // Status to manage whether to display results
-  const resultsRef = useRef<HTMLDivElement>(null); // 创建一个引用
+  const resultsRef = useRef<HTMLDivElement>(null); // Create a reference
 
   const handleProceedClick = () => {
     setShowResults(true); // Set to true to show the Results component
@@ -15,13 +15,13 @@ export default function Page() {
 
   useEffect(() => {
     if (showResults && resultsRef.current) {
-      resultsRef.current.scrollIntoView({ behavior: 'smooth' }); // 平滑滚动到 Results 部分
+      resultsRef.current.scrollIntoView({ behavior: 'smooth' }); // Smooth scrolling to the Results section
     }
   }, [showResults]);
 
   return (
     <div className={style.main}>
-      {/* 显示 HomePage */}
+      {/* display HomePage */}
       <div className={style['home-container']}>
         <HomePage />
       </div>


### PR DESCRIPTION

This PR fixes the issue where clicking the Proceed button only scrolls to the result section the first time. The new implementation ensures that:
On the first click, the results section is displayed and automatically scrolled into view.
On subsequent clicks, the page will scroll to the results section without reloading the content unnecessarily.
The scrolling now properly aligns with the results section, leaving a small offset to ensure the section is properly visible.